### PR TITLE
Prenvent OpenSSL <= 3.0.0 + Improving GH Actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: "CodeQL code analysis"
 
 on:
   push:
@@ -64,10 +64,12 @@ jobs:
     #   If the Autobuild fails above, remove it and uncomment the following three lines. 
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    - run: |
-       echo "Building the application"
-       make all
+    - name: Installation des dépendances de SherlockFS
+      run: timeout $((2*60)) bash dependencies.sh
 
-    - name: Perform CodeQL Analysis
+    - name: Compilation du projet SherlockFS
+      run: make
+
+    - name: Analyse du code avec CodeQL
       uses: github/codeql-action/analyze@v2
 

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -29,7 +29,7 @@ jobs:
           sudo cp -r /tmp/criterion/criterion-v2.3.3/include/* /usr/local/include
 
       - name: Installation des dépendances de SherlockFS
-        run: timeout $((2*60)) bash dependencies.sh
+        run: timeout $((2*60)) sudo bash dependencies.sh
 
       - name: Lancement de la suite de tests (`make check`)
         run: timeout $((2*60)) make check

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -32,4 +32,4 @@ jobs:
         run: timeout $((2*60)) sudo bash dependencies.sh
 
       - name: Lancement de la suite de tests (`make check`)
-        run: timeout $((2*60)) make check
+        run: timeout $((2*60)) make -j check

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test_suite:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
 
@@ -27,5 +28,8 @@ jobs:
           sudo cp -r /tmp/criterion/criterion-v2.3.3/lib/* /usr/lib &&
           sudo cp -r /tmp/criterion/criterion-v2.3.3/include/* /usr/local/include
 
+      - name: Installation des dépendances de SherlockFS
+        run: timeout $((2*60)) bash dependencies.sh
+
       - name: Lancement de la suite de tests (`make check`)
-        run: make check
+        run: timeout $((2*60)) make check

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ MOUNT_SRC = $(SRC_DIR)/mount_fuse.c
 MOUNT_OBJ = $(subst $(PROJECT_DIR),$(BUILD_DIR),$(MOUNT_SRC:.c=.o))
 
 all : shlkfs_formater mount shlkfs_adduser
+
+dependencies:
+	bash dependencies.sh
 	
 shlkfs_formater: $(BUILD_DIR)/shlkfs_formater
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Un troisième outil, `mount`, est prévu pour une intégration future après la 
 
 ## Prérequis
 
-Avant de démarrer, il est nécessaire d'installer les dépendances. Exécutez `make dependencies`. Ce script est compatible uniquement avec les gestionnaires de paquets `apt` ou `pacman`.
+Avant de démarrer, il est nécessaire d'installer les dépendances. Exécutez `sudo make dependencies`. Ce script est compatible uniquement avec les gestionnaires de paquets `apt` ou `pacman`.
 
 ## Compilation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Un troisième outil, `mount`, est prévu pour une intégration future après la 
 
 ## Prérequis
 
-Avant de démarrer, il est nécessaire d'installer les dépendances. Exécutez `bash dependencies.sh`. Ce script est compatible uniquement avec les gestionnaires de paquets `apt` ou `pacman`.
+Avant de démarrer, il est nécessaire d'installer les dépendances. Exécutez `make dependencies`. Ce script est compatible uniquement avec les gestionnaires de paquets `apt` ou `pacman`.
 
 ## Compilation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Un troisième outil, `mount`, est prévu pour une intégration future après la 
 
 ## Prérequis
 
-Avant de démarrer, il est nécessaire d'installer les dépendances. Exécutez `sudo make dependencies`. Ce script est compatible uniquement avec les gestionnaires de paquets `apt` ou `pacman`.
+Avant de démarrer, il est nécessaire d'installer les dépendances. Exécutez `bash dependencies.sh`. Ce script est compatible uniquement avec les gestionnaires de paquets `apt` ou `pacman`.
 
 ## Compilation
 

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -1,13 +1,73 @@
 #!/bin/bash
+
+# Exit on error
+set -e
+
+green() {
+    echo -e "\e[32m$1\e[0m"
+}
+
+yellow() {
+    echo -e "\e[33m$1\e[0m"
+}
+
 if [ -x "$(command -v apt)" ]; then
     sudo apt update
     sudo apt install -y \
         build-essential make libssl-dev libfuse-dev
+
+    green "Dependencies installed successfully"
 elif [ -x "$(command -v yum)" ]; then
     sudo pacman -Syu
     sudo pacman -S --noconfirm \
         base-devel make libssl-dev libfuse-dev
+
+    green "Dependencies installed successfully"
 else
-    echo "Unsupported OS"
+    red "Unsupported OS"
     exit 1
 fi
+
+manual_openssl_install() {
+    ossl_version="3.2.0"
+    # Ask user if he wants to install OpenSSL $ossl_version
+    read -p "Do you want to install OpenSSL '$ossl_version' (using manual wget, tar and make)? [y/n] " -n 1 -r REPLY
+
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo -e "\nExiting..."
+        exit 1
+    fi
+
+    echo "Downloading and installing OpenSSL '$ossl_version'"
+    # Creating temporary directory
+    tmp_dir=$(mktemp -d)
+
+    wget https://www.openssl.org/source/openssl-$ossl_version.tar.gz -P $tmp_dir
+    cd $tmp_dir
+    tar -xzf openssl-$ossl_version.tar.gz
+    cd openssl-$ossl_version
+    sudo ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
+    sudo make -j && sudo make -j install
+
+    # Cleaning temporary directory
+    rm -rf $tmp_dir
+
+    green "OpenSSL '$ossl_version' installed successfully"
+}
+
+# Check that openssl version is 3.0.0 or higher
+echo "Checking OpenSSL version..."
+if [ -x "$(command -v openssl)" ]; then
+    openssl_version=$(openssl version | awk '{print $2}')
+    if [ "$(printf '%s\n' "3.0.0" "$openssl_version" | sort -V | head -n1)" = "3.0.0" ]; then
+        green "OpenSSL version is '$openssl_version', OK for SherlockFS"
+    else
+        yellow "OpenSSL version is '$openssl_version', KO for SherlockFS: must be 3.0.0 or higher"
+        manual_openssl_install
+    fi
+else
+    red "OpenSSL not installed"
+    manual_openssl_install
+fi
+
+exit 0

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -15,16 +15,12 @@ if [ -x "$(command -v apt)" ]; then
     sudo apt update
     sudo apt install -y \
         build-essential make libssl-dev libfuse-dev
-
-    green "Dependencies installed successfully"
 elif [ -x "$(command -v yum)" ]; then
     sudo pacman -Syu
     sudo pacman -S --noconfirm \
         base-devel make libssl-dev libfuse-dev
-
-    green "Dependencies installed successfully"
 else
-    red "Unsupported OS"
+    red "Unsupported OS: Your system must use 'apt' or 'pacman' packages managers"
     exit 1
 fi
 
@@ -38,7 +34,7 @@ manual_openssl_install() {
         exit 1
     fi
 
-    echo "Downloading and installing OpenSSL '$ossl_version'"
+    echo "Downloading, configuring, compiling and installing OpenSSL '$ossl_version'"
     # Creating temporary directory
     tmp_dir=$(mktemp -d)
 
@@ -69,5 +65,7 @@ else
     red "OpenSSL not installed"
     manual_openssl_install
 fi
+
+green "Dependencies installed successfully!"
 
 exit 0

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -21,7 +21,7 @@ if [ -x "$(command -v apt)" ]; then
     apt update
     apt install -y \
         build-essential make libssl-dev libfuse-dev
-elif [ -x "$(command -v yum)" ]; then
+elif [ -x "$(command -v pacman)" ]; then
     pacman -Syu
     pacman -S --noconfirm \
         base-devel make libssl-dev libfuse-dev
@@ -29,43 +29,6 @@ else
     red "Unsupported OS: Your system must use 'apt' or 'pacman' packages managers"
     exit 1
 fi
-
-manual_openssl_install() {
-    ossl_version="3.2.0"
-    # Ask user if he wants to install OpenSSL $ossl_version
-    read -p "Do you want to install OpenSSL '$ossl_version' (using manual wget, tar and make)? [y/n] " -n 1 -r REPLY
-
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        echo -e "\nExiting..."
-        exit 1
-    fi
-
-    if [ -x "$(command -v apt)" ]; then
-        apt remove -y openssl libssl-dev
-    elif [ -x "$(command -v yum)" ]; then
-        pacman -R openssl libssl-dev
-    fi
-
-    echo "Downloading, configuring, compiling and installing OpenSSL '$ossl_version'"
-    # Creating temporary directory
-    tmp_dir=$(mktemp -d)
-
-    wget https://www.openssl.org/source/openssl-$ossl_version.tar.gz -P $tmp_dir
-    cd $tmp_dir
-    tar -xzf openssl-$ossl_version.tar.gz
-    cd openssl-$ossl_version
-    ./config
-    make -j
-    make -j install
-
-    ldconfig
-    ln -s /usr/local/bin/openssl /usr/bin/
-
-    # Cleaning temporary directory
-    rm -rf $tmp_dir
-
-    green "OpenSSL '$ossl_version' installed successfully"
-}
 
 # Check that openssl version is 3.0.0 or higher
 echo "Checking OpenSSL version..."
@@ -75,13 +38,13 @@ if [ -x "$(command -v openssl)" ]; then
         green "OpenSSL version is '$openssl_version', OK for SherlockFS"
     else
         yellow "OpenSSL version is '$openssl_version', KO for SherlockFS: must be 3.0.0 or higher"
-        manual_openssl_install
+        yellow "You must install OpenSSL 3.0.0 or higher by yourself"
+        exit 1
     fi
 else
     red "OpenSSL not installed"
-    manual_openssl_install
+    exit 1
 fi
 
 green "Dependencies installed successfully!"
-
 exit 0

--- a/src/fs/filesystem/adduser.c
+++ b/src/fs/filesystem/adduser.c
@@ -48,6 +48,10 @@ int cryptfs_adduser(char *device_path, char *other_public_key_path,
             "The user with the public key '%s' is already in the keys "
             "storage of the device '%s'\n",
             other_public_key_path, device_path);
+        free(cryptfs);
+        free(passphrase);
+        EVP_PKEY_free(my_rsa);
+        EVP_PKEY_free(other_rsa);
         return -1;
     }
 


### PR DESCRIPTION
## OpenSSL >= 3.0.0 check

Version of OpenSSL $\lt$ 3.0.0 conducts to compilation errors.

`dependencies.sh` now checks if OpenSSL $\geq$ 3.0.0.

## Github Actions workflows improvement

Read the code.